### PR TITLE
Improved Graphviz visualizer.

### DIFF
--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -74,11 +74,15 @@ namespace VSharp
         private static Statistics StartExploration(List<MethodBase> methods, string resultsFolder, string[] mainArguments = null)
         {
             var maxBound = 15u;
-            var options =
-                new SiliOptions(explorationMode.NewTestCoverageMode(coverageZone.MethodZone, searchMode.DFSMode),
-                    executionMode.SymbolicMode, maxBound);
-            SILI explorer = new SILI(options);
             UnitTests unitTests = new UnitTests(resultsFolder);
+            var options =
+                new SiliOptions(
+                    explorationMode.NewTestCoverageMode(coverageZone.MethodZone, searchMode.DFSMode),
+                    executionMode.SymbolicMode,
+                    unitTests.TestDirectory,
+                    maxBound,
+                    false);
+            SILI explorer = new SILI(options);
             Core.API.ConfigureSolver(SolverPool.mkSolver());
             foreach (var method in methods)
             {

--- a/VSharp.IL/DotVisualizer.fs
+++ b/VSharp.IL/DotVisualizer.fs
@@ -1,0 +1,96 @@
+namespace VSharp.Interpreter.IL
+
+open System
+open System.Collections.Generic
+open System.Diagnostics
+open System.IO
+open VSharp
+open VSharp.Core
+
+type DotVisualizer(graph : ApplicationGraph, outputDirectory : DirectoryInfo) =
+    let dotPath = Environment.GetEnvironmentVariable("DOT_PATH")
+    let dotPath = if String.IsNullOrWhiteSpace dotPath then "dot" else dotPath
+    let dotFile = Path.GetTempFileName()
+    let outputDirectory = outputDirectory.CreateSubdirectory("visualization")
+    let ids = Dictionary<codeLocation, string>()
+    let mutable lastVertexId = 0
+    let mutable lastPictureId = 0
+    let stateMarkers = Dictionary<codeLocation, int>()
+    let visitedVertices = HashSet<codeLocation>()
+    let visitedEdges = HashSet<codeLocation * codeLocation>()
+
+    let leave loc =
+        stateMarkers.[loc] <- stateMarkers.[loc] - 1
+    let visit loc =
+        visitedVertices.Add loc |> ignore
+        if stateMarkers.ContainsKey loc then stateMarkers.[loc] <- stateMarkers.[loc] + 1
+        else stateMarkers.Add(loc, 1)
+    let move fromLoc toLoc =
+        visit toLoc
+        visitedEdges.Add(fromLoc, toLoc) |> ignore
+
+    let id loc = Dict.getValueOrUpdate ids loc (fun () -> lastVertexId <- lastVertexId + 1; $"v{lastVertexId}")
+    let visitedColor = "#D3D3D3B4"
+    let unvisitedColor = "#000000"
+    let colorOfNode loc =
+        let markers = Dict.tryGetValue stateMarkers loc 0
+        if markers > 0 then
+            let alpha = 256 - 128 / (1 <<< (min 7 markers))
+            let r, g, b = 0xCC, 0x88, 0x99
+            sprintf "#%x%x%x%x" r g b alpha, "filled"
+        elif visitedVertices.Contains loc then visitedColor, "filled"
+        else unvisitedColor, "\"\""
+    let colorOfEdge fromLoc toLoc =
+        if visitedEdges.Contains(fromLoc, toLoc) then visitedColor else unvisitedColor
+
+    let node (cfg : CfgInfo) loc =
+        let color, style = colorOfNode loc
+        let text = (cfg.BasicBlockToString loc.offset |> join "\\l") + "\\l"
+        $"{id loc} [shape=ellipse, label=\"{text}\", color=\"{color}\", style={style}]"
+    let edge fromLoc toLoc =
+        $"{id fromLoc} -> {id toLoc} [color=\"{colorOfEdge fromLoc toLoc}\"]"
+
+    let cfgToDot (cfg : CfgInfo) =
+        seq{
+            let name = cfg.MethodBase.Name // TODO: declaring type & overloads!
+            yield $"subgraph cluster_%s{name} {{"
+            yield $"label=%A{name}"
+            for vertex in cfg.SortedOffsets do
+                yield node cfg {method = cfg.MethodBase; offset = vertex}
+            for kvp in cfg.Edges do
+                let from = {method = cfg.MethodBase; offset = kvp.Key}
+                for toOffset in kvp.Value do
+                    let toLoc = {method = cfg.MethodBase; offset = toOffset}
+                    yield edge from toLoc
+            yield "}"
+        }
+
+    member private x.Compile() =
+        lastPictureId <- lastPictureId + 1
+        let format = "0000000000"
+        let output = $"{outputDirectory.FullName}{Path.DirectorySeparatorChar}Step{lastPictureId.ToString(format)}.png"
+        let startInfo = ProcessStartInfo()
+        startInfo.FileName <- dotPath
+        startInfo.Arguments <- $"-Tpng {dotFile} -o {output}"
+        Process.Start(startInfo) |> ignore
+
+    interface IVisualizer with
+
+        override x.AddMarker loc = visit loc
+
+        override x.VisualizeGraph () =
+            let dot = seq {
+               yield "digraph G"
+               yield "{"
+               for cfg in graph.CFGs do
+                   yield! cfgToDot cfg
+               yield "}"
+            }
+            File.WriteAllLines(dotFile, dot)
+            x.Compile()
+
+        override x.VisualizeStep fromLoc toLoc newMarkers =
+            leave fromLoc
+            move fromLoc toLoc
+            newMarkers |> Seq.iter (move fromLoc)
+            (x :> IVisualizer).VisualizeGraph()

--- a/VSharp.IL/GraphQueryEngine.fs
+++ b/VSharp.IL/GraphQueryEngine.fs
@@ -66,12 +66,6 @@ type StartVertex =
     new (vertex, callHistory) = {Vertex = vertex; CallHistory = callHistory}
 
 [<Struct>]
-type Cluster =
-    val Name: string
-    val Vertices: seq<int<inputGraphVertex>>
-    new (name, vertices) = {Name = name; Vertices = vertices}
-
-[<Struct>]
 type Edge =
     val StartVertex: int<inputGraphVertex>
     val FinalVertex: int<inputGraphVertex>
@@ -303,28 +297,3 @@ type GraphQueryEngine() as this =
         
     member this.GetDistanceToNearestGoal startVertex =
         distancesCache.[startVertex].GetNearestVertex()
-    
-    member this.ToDot (clusters, filePath) =
-        let subgraphs =
-            seq{
-                for cluster:Cluster in clusters do
-                    yield $"subgraph cluster_%s{cluster.Name} {{"
-                    yield $"label=%A{cluster.Name}"                    
-                    for vertex in cluster.Vertices do
-                        yield string vertex
-                    yield "}"  
-            }
-                       
-        let content =
-            seq{
-               yield "digraph G"
-               yield "{"
-               yield "node [shape = plaintext]"
-               yield! subgraphs
-               for kvp in vertices do
-                for e in kvp.Value do
-                    yield $"%i{kvp.Key} -> %i{e.TargetVertex} [label=%A{e.TerminalSymbol}]"
-               yield "}"
-            }
-        
-        System.IO.File.WriteAllLines(filePath, content)

--- a/VSharp.IL/VSharp.IL.fsproj
+++ b/VSharp.IL/VSharp.IL.fsproj
@@ -13,6 +13,7 @@
       <Compile Include="GraphQueryEngine.fs" />
       <Compile Include="CFG.fs" />
       <Compile Include="Coverage.fs" />
+      <Compile Include="DotVisualizer.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/VSharp.SILI.Core/State.fs
+++ b/VSharp.SILI.Core/State.fs
@@ -11,6 +11,7 @@ type typeVariables = mappedStack<typeId, symbolicType> * typeId list stack
 
 type stackBufferKey = concreteHeapAddress
 
+// TODO: alias int<measure>?
 type offset = int
 
 // last fields are determined by above fields

--- a/VSharp.SILI/Options.fs
+++ b/VSharp.SILI/Options.fs
@@ -1,6 +1,7 @@
 ﻿namespace VSharp.Interpreter.IL
 
 open System.Diagnostics
+open System.IO
 
 type searchMode =
     | DFSMode
@@ -19,5 +20,10 @@ type executionMode =
     | ConcolicMode
     | SymbolicMode
 
-type SiliOptions =
-    {explorationMode : explorationMode; executionMode : executionMode; bound : uint32}
+type SiliOptions = {
+    explorationMode : explorationMode
+    executionMode : executionMode
+    outputDirectory : DirectoryInfo
+    bound : uint32
+    visualize : bool
+}

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -91,9 +91,14 @@ namespace VSharp.Test
                 var methodInfo = innerCommand.Test.Method.MethodInfo;
                 try
                 {
-                    _options = new SiliOptions(explorationMode.NewTestCoverageMode(coverageZone.MethodZone, searchMode.DFSMode), _executionMode, _maxBoundForTest);
-                    SILI explorer = new SILI(_options);
                     UnitTests unitTests = new UnitTests(Directory.GetCurrentDirectory());
+                    _options = new SiliOptions(
+                        explorationMode.NewTestCoverageMode(coverageZone.MethodZone, searchMode.DFSMode),
+                        _executionMode,
+                        unitTests.TestDirectory,
+                        _maxBoundForTest,
+                        false);
+                    SILI explorer = new SILI(_options);
 
                     explorer.InterpretIsolated(methodInfo, unitTests.GenerateTest, unitTests.GenerateError, _ => { }, e => throw e);
 


### PR DESCRIPTION
Now visualizer renders CFG in more fancy manner:

![image](https://user-images.githubusercontent.com/734254/179525352-06190574-5a02-483d-9976-ff2c205f9b29.png)

Covered blocks and edges are rendered with grey, blocks with states are rendered with purple (more states in block -> more dark the color of the block). 

By default, the visualizer is disabled. To enable it, [set the `visualize` flag of `SILIOptions` to `true`](https://github.com/VSharp-team/VSharp/blob/db063bf6b2f90d8b70b3ab9808efa1b83c9cbad8/VSharp.Test/IntegrationTests.cs#L100). The CFGs would be rendered into the `visualization` subdirectory destination test generation directory (usually it is `VSharp.Test/bin/Debug(Release)/netcoreapp6.0/VSharp.tests.last/visualization`

**Note:** for more fancy layouting, call edges are not rendered for now.
