### PR TITLE
Add messages encoder+decoder, add game structs

### DIFF
--- a/VSharp.ML.AIAgent/agent.py
+++ b/VSharp.ML.AIAgent/agent.py
@@ -1,16 +1,38 @@
 import websocket
+from messages import *
+from game import *
 
-ws = websocket.WebSocket()
-ws.connect("ws://0.0.0.0:8080/gameServer")
-ws.send('{"MessageType":"getallmaps","MessageBody":"dd"}')
-data = ws.recv()
-print("Received 1", repr(data))
-ws.send('{"MessageType":"start","MessageBody":"{\\"MapId\\":0,\\"StepsToPlay\\":10}"}')
-data = ws.recv()
-print("Received 2", repr(data))
-ws.send(
-    '{"MessageType":"step","MessageBody":"{\\"StateId\\":0,\\"PredictedStateUsefulness\\":1.0}"}'
-)
-data = ws.recv()
-print("Received 3", repr(data))
-ws.close()
+
+def beautify_json(j):
+    return json.dumps(json.loads(j), indent=4)
+
+
+def main():
+    ws = websocket.WebSocket()
+    ws.connect("ws://0.0.0.0:8080/gameServer")
+
+    requestAllMapsMessage = Message(GetAllMapsMessageBody()).dumps()
+    print(requestAllMapsMessage)
+    ws.send(requestAllMapsMessage)
+    recieved = ws.recv()
+    mapSettings = [GameMap.from_dict(item) for item in json.loads(recieved)]
+    print("Received 1", mapSettings, end="\n")
+
+    startMessage = Message(StartMessageBody(MapId=0, StepsToPlay=10)).dumps()
+    print(startMessage)
+    ws.send(startMessage)
+    data = GameState.from_json(ws.recv())
+    print("Received 2", data, end="\n")
+
+    doStepMessage = Message(
+        StepMessageBody(StateId=0, PredictedStateUsefulness=1.0)
+    ).dumps()
+    ws.send(doStepMessage)
+    recieved = ws.recv()
+    data = Reward.from_json(recieved)
+    print("Received 3", data, end="\n")
+    ws.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/VSharp.ML.AIAgent/agent.py
+++ b/VSharp.ML.AIAgent/agent.py
@@ -1,15 +1,18 @@
 import websocket
 from messages import *
 from game import *
-
-
-def beautify_json(j):
-    return json.dumps(json.loads(j), indent=4)
+import argparse
 
 
 def main():
+    default_server_url = "ws://0.0.0.0:8080/gameServer"
+    argParser = argparse.ArgumentParser()
+    argParser.add_argument("-u", "--url", help="game server url")
+    args = argParser.parse_args()
+    url = args.url if args.url != None else default_server_url
+
     ws = websocket.WebSocket()
-    ws.connect("ws://0.0.0.0:8080/gameServer")
+    ws.connect(url)
 
     requestAllMapsMessage = Message(GetAllMapsMessageBody()).dumps()
     print(requestAllMapsMessage)

--- a/VSharp.ML.AIAgent/agent.py
+++ b/VSharp.ML.AIAgent/agent.py
@@ -14,26 +14,28 @@ def main():
     ws = websocket.WebSocket()
     ws.connect(url)
 
-    requestAllMapsMessage = Message(GetAllMapsMessageBody()).dumps()
+    requestAllMapsMessage = ClientMessage(GetAllMapsMessageBody())
     print(requestAllMapsMessage)
-    ws.send(requestAllMapsMessage)
+    ws.send(requestAllMapsMessage.to_json())
     recieved = ws.recv()
-    mapSettings = [GameMap.from_dict(item) for item in json.loads(recieved)]
-    print("Received 1", mapSettings, end="\n")
+    mapSettings = ServerMessage.from_json(recieved)
+    print("Received 1: ", mapSettings, end="\n")
 
-    startMessage = Message(StartMessageBody(MapId=0, StepsToPlay=10)).dumps()
+    startMessage = ClientMessage(StartMessageBody(MapId=0, StepsToPlay=10))
     print(startMessage)
-    ws.send(startMessage)
-    data = GameState.from_json(ws.recv())
-    print("Received 2", data, end="\n")
-
-    doStepMessage = Message(
-        StepMessageBody(StateId=0, PredictedStateUsefulness=1.0)
-    ).dumps()
-    ws.send(doStepMessage)
+    ws.send(startMessage.to_json())
     recieved = ws.recv()
-    data = Reward.from_json(recieved)
-    print("Received 3", data, end="\n")
+    data = GameState.from_json(recieved)
+    print("Received 2: ", data, end="\n")
+
+    doStepMessage = ClientMessage(
+        StepMessageBody(StateId=0, PredictedStateUsefulness=1.0)
+    )
+    print(doStepMessage)
+    ws.send(doStepMessage.to_json())
+    recieved = ws.recv()
+    data = ServerMessage.from_json(recieved)
+    print("Received 3: ", data, end="\n")
     ws.close()
 
 

--- a/VSharp.ML.AIAgent/game.py
+++ b/VSharp.ML.AIAgent/game.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json, config
 from typing import List
+import json
 
 
 @dataclass_json
@@ -63,3 +64,12 @@ class GameMap:
     AssemblyFullName: str
     CoverageZone: bool
     NameOfObjectToCover: str
+
+
+@dataclass_json
+@dataclass
+class ServerMessage:
+    MessageType: str
+    MessageBody: List[GameMap] | Reward = field(
+        metadata=config(decoder=lambda x: json.loads(x))
+    )

--- a/VSharp.ML.AIAgent/game.py
+++ b/VSharp.ML.AIAgent/game.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+from typing import List
+
+
+@dataclass_json
+@dataclass
+class State:
+    Id: int
+    Position: int
+    PredictedUsefulness: float
+    PathConditionSize: int
+    VisitedAgainVertices: int
+    VisitedNotCoveredVerticesInZone: int
+    VisitedNotCoveredVerticesOutOfZone: int
+
+
+@dataclass_json
+@dataclass
+class GameMapVertex:
+    Uid: int
+    Id: int
+    InCoverageZone: bool
+    BasicBlockSize: int
+    CoveredByTest: bool
+    VisitedByState: bool
+    TouchedByState: bool
+    States: List[State]
+
+
+@dataclass_json
+@dataclass
+class GameEdgeLabel:
+    Token: int
+
+
+@dataclass_json
+@dataclass
+class GameMapEdge:
+    VertexFrom: GameMapVertex
+    VertexTo: GameMapVertex
+    Label: GameEdgeLabel
+
+
+@dataclass_json
+@dataclass
+class GameState:
+    Map: List[GameMapEdge]
+
+
+@dataclass_json
+@dataclass
+class Reward:
+    StepReward: int
+    MaxPossibleReward: int
+
+
+@dataclass_json
+@dataclass
+class GameMap:
+    Id: int
+    CoverageToStart: int
+    AssemblyFullName: str
+    CoverageZone: bool
+    NameOfObjectToCover: str

--- a/VSharp.ML.AIAgent/messages.py
+++ b/VSharp.ML.AIAgent/messages.py
@@ -53,12 +53,3 @@ class Message:
 
     def dumps(self) -> str:
         return json.dumps(asdict(self, dict_factory=factory))
-
-
-def main():
-    msg = Message(StartMessageBody(MapId=0, StepsToPlay=10))
-    print(msg.dumps())
-
-
-if __name__ == "__main__":
-    main()

--- a/VSharp.ML.AIAgent/messages.py
+++ b/VSharp.ML.AIAgent/messages.py
@@ -1,0 +1,64 @@
+from dataclasses import asdict, dataclass, field
+import json
+
+
+class MessageBody:
+    def type() -> str:
+        pass
+
+
+@dataclass
+class GetAllMapsMessageBody(MessageBody):
+    def type(self):
+        return "getallmaps"
+
+
+@dataclass
+class StartMessageBody(MessageBody):
+    MapId: int
+    StepsToPlay: int
+
+    def type(self):
+        return "start"
+
+
+@dataclass
+class StepMessageBody(MessageBody):
+    StateId: int
+    PredictedStateUsefulness: float
+
+    def type(self):
+        return "step"
+
+
+def factory(data):
+    # for now only one level of nested structures supported
+    dict = {}
+
+    for (key, value) in data:
+        if type(value) in (str, int, float):
+            dict[key] = value
+        else:
+            dict[key] = json.dumps(value)
+    return dict
+
+
+@dataclass
+class Message:
+    MessageType: str = field(init=False)
+    MessageBody: MessageBody
+
+    def __post_init__(self):
+        self.MessageType = self.MessageBody.type()
+
+    def dumps(self) -> str:
+        return json.dumps(asdict(self, dict_factory=factory))
+
+
+def main():
+    msg = Message(StartMessageBody(MapId=0, StepsToPlay=10))
+    print(msg.dumps())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Добавил также структуры для сериализации/десериализации ответа сервера.

Примечание: вложенные структуры при отсылке нужно дампить дважды:
`{"MessageType": "start", "MessageBody": "{\"MapId\": 0, \"StepsToPlay\": 10}"}`,
а не
`{"MessageType": "start", "MessageBody": {"MapId": 0, "StepsToPlay": 10}}`

Нашел красивый способ поддержать вложенные структуры, присылаемые с сервера с помощью кастомных енкодеров/декодеров полей

Отделил ServerMessage от ClientMessage чтобы не путаться при их использовании