### PR TITLE
Fix gameover

### DIFF
--- a/VSharp.ML.AIAgent/agent/connection_manager.py
+++ b/VSharp.ML.AIAgent/agent/connection_manager.py
@@ -4,7 +4,7 @@ import websocket
 
 class ConnectionManager:
     def __init__(self, urls: list[str]) -> None:
-        self.socket_q = Queue()
+        self.socket_q: Queue[websocket.WebSocket] = Queue()
         for url in urls:
             self.socket_q.put(websocket.create_connection(url))
 

--- a/VSharp.ML.AIAgent/agent/connection_manager.py
+++ b/VSharp.ML.AIAgent/agent/connection_manager.py
@@ -1,0 +1,21 @@
+from queue import Queue
+import websocket
+
+
+class ConnectionManager:
+    def __init__(self, urls: list[str]) -> None:
+        self.socket_q = Queue()
+        for url in urls:
+            self.socket_q.put(websocket.create_connection(url))
+
+    def issue(self) -> websocket.WebSocket:
+        return self.socket_q.get()
+
+    def release(self, ws: websocket.WebSocket):
+        self.socket_q.put(ws)
+
+    def close(self):
+        self.socket_q.empty()
+        while not self.socket_q.empty():
+            s = self.socket_q.get()
+            s.close()

--- a/VSharp.ML.AIAgent/agent/n_agent.py
+++ b/VSharp.ML.AIAgent/agent/n_agent.py
@@ -1,4 +1,3 @@
-from .connection_manager import ConnectionManager
 from common.game import GameMap
 from common.game import GameState
 from common.messages import Reward
@@ -12,6 +11,7 @@ from common.messages import MapsServerMessage
 from common.messages import GameOverServerMessage
 from common.messages import GameStateServerMessage
 from common.messages import RewardServerMessage
+from .connection_manager import ConnectionManager
 
 
 def get_server_maps(cm: ConnectionManager) -> list[GameMap]:

--- a/VSharp.ML.AIAgent/agent/test_server_connection.py
+++ b/VSharp.ML.AIAgent/agent/test_server_connection.py
@@ -17,7 +17,7 @@ def get_states(game_state: GameState) -> set[int]:
     return states
 
 
-def choose_state_id(game_state: GameState) -> int:
+def dumb_strategy(game_state: GameState) -> int:
     return get_states(game_state).pop()
 
 
@@ -34,7 +34,7 @@ class TestServerConnection(unittest.TestCase):
 
     def do_one_dumb_step(self, with_agent: NAgent) -> Reward:
         game_state = with_agent.recv_state_or_throw_gameover().MessageBody
-        next_state = choose_state_id(game_state)
+        next_state = dumb_strategy(game_state)
         with_agent.send_step(next_state_id=next_state, predicted_usefullness=42.0)
         return with_agent.recv_reward_or_throw_gameover()
 

--- a/VSharp.ML.AIAgent/agent/test_server_connection.py
+++ b/VSharp.ML.AIAgent/agent/test_server_connection.py
@@ -3,6 +3,7 @@ import unittest
 
 from common.game import GameState, Reward
 from .n_agent import NAgent, get_server_maps
+from .connection_manager import ConnectionManager
 
 
 def get_states(game_state: GameState) -> set[int]:
@@ -21,41 +22,56 @@ def choose_state_id(game_state: GameState) -> int:
 
 
 class TestServerConnection(unittest.TestCase):
-    def setUp(self):
-        self.server_url = "ws://0.0.0.0:8080/gameServer"
-        maps = get_server_maps(self.server_url)
-        self.test_map_id = maps[0].Id
-        self.n_steps = 5
+    @classmethod
+    def setUpClass(cls):
+        urls = ["ws://0.0.0.0:8080/gameServer"]
 
-    def do_one_step(self, with_agent: NAgent) -> Reward | NAgent.StepsCount:
-        next_state = choose_state_id(with_agent.recv_state_from_server().MessageBody)
+        cls.n_steps = 1
+        cls.cm = ConnectionManager(urls)
+
+        maps = get_server_maps(cls.cm)
+        cls.test_map_id = maps[0].Id
+
+    def do_one_dumb_step(self, with_agent: NAgent) -> Reward:
+        game_state = with_agent.recv_state_or_throw_gameover().MessageBody
+        next_state = choose_state_id(game_state)
         with_agent.send_step(next_state_id=next_state, predicted_usefullness=42.0)
-        return with_agent.recv_reward()
-
-    def test_n_steps_doesnt_throw(self):
-        with closing(
-            NAgent(self.server_url, map_id_to_play=self.test_map_id, steps=self.n_steps)
-        ) as agent:
-            for _ in range(self.n_steps):
-                match self.do_one_step(with_agent=agent):
-                    case Reward():
-                        pass
-                    case NAgent.StepsCount:
-                        break
+        return with_agent.recv_reward_or_throw_gameover()
 
     def test_n_plus_one_step_throws_gameover(self):
+        """
+        N steps on map 0 with dumb strategy should throw gameover
+        """
         with closing(
-            NAgent(self.server_url, map_id_to_play=self.test_map_id, steps=self.n_steps)
+            NAgent(self.cm, map_id_to_play=self.test_map_id, steps=self.n_steps)
         ) as agent:
             for _ in range(self.n_steps):
-                match self.do_one_step(with_agent=agent):
-                    case Reward():
-                        pass
-                    case NAgent.StepsCount:
-                        break
-
-            self.do_one_step(with_agent=agent)  # receive gameover
+                self.do_one_dumb_step(with_agent=agent)
 
             self.assertRaises(
-                NAgent.WrongAgentStateError, lambda: self.do_one_step(with_agent=agent)
-            )
+                NAgent.GameOver, lambda: self.do_one_dumb_step(with_agent=agent)
+            )  # fake step to check for gameover
+
+    def test_multiple_agents(self):
+        """
+        Launching multible agents in a row should be possible
+        """
+        for _ in range(10):
+            with closing(
+                NAgent(
+                    self.cm,
+                    map_id_to_play=self.test_map_id,
+                    steps=self.n_steps,
+                )
+            ) as agent:
+                try:
+                    for _ in range(self.n_steps):
+                        self.do_one_dumb_step(with_agent=agent)
+                    self.do_one_dumb_step(with_agent=agent)  # fake step
+
+                except NAgent.GameOver:
+                    pass
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.cm.close()

--- a/VSharp.ML.AIAgent/common/game.py
+++ b/VSharp.ML.AIAgent/common/game.py
@@ -71,13 +71,14 @@ class MoveReward:
     ForCoverage: int
     ForVisitedInstructions: int
 
-    def __eq__(self, __o: "MoveReward") -> bool:
+    def __eq__(self, __o) -> bool:
         if type(self) != type(__o):
-            return RuntimeError(f"Can't compare {type(self)} with {type(__o)}")
+            raise RuntimeError(f"Can't compare {type(self)} with {type(__o)}")
+        return self == __o
 
     def __add__(self, __o: "MoveReward") -> "MoveReward":
         if type(self) != type(__o):
-            return RuntimeError(f"Can't add {type(__o)} to {type(self)}")
+            raise RuntimeError(f"Can't add {type(__o)} to {type(self)}")
         return MoveReward(
             self.ForCoverage + __o.ForCoverage,
             self.ForVisitedInstructions + __o.ForVisitedInstructions,

--- a/VSharp.ML.AIAgent/common/messages.py
+++ b/VSharp.ML.AIAgent/common/messages.py
@@ -1,7 +1,7 @@
 from dataclasses_json import dataclass_json, config
 from dataclasses import dataclass, field
-import json
 from enum import Enum
+import json
 
 from .game import GameMap, GameState, Reward
 

--- a/VSharp.ML.AIAgent/common/messages.py
+++ b/VSharp.ML.AIAgent/common/messages.py
@@ -79,19 +79,28 @@ class ServerMessageType(str, Enum):
 @dataclass_json
 @dataclass
 class ServerMessage:
-    def decode(x):
-        if x == "" or x == {}:
-            return x
-
-        for MessageBodyType in [MapsMessageBody, Reward, GameState]:
-            try:
-                return MessageBodyType.from_dict(x)
-            except (KeyError, ValueError, AttributeError):
-                pass
-
-        raise RuntimeError(f"Can't decode msg: {x}")
-
     MessageType: ServerMessageType
-    MessageBody: MapsMessageBody | Reward | GameState = field(
-        metadata=config(decoder=decode)
-    )
+
+
+@dataclass_json
+@dataclass
+class GameStateServerMessage(ServerMessage):
+    MessageBody: GameState
+
+
+@dataclass_json
+@dataclass
+class RewardServerMessage(ServerMessage):
+    MessageBody: Reward
+
+
+@dataclass_json
+@dataclass
+class MapsServerMessage(ServerMessage):
+    MessageBody: MapsMessageBody
+
+
+@dataclass_json
+@dataclass
+class GameOverServerMessage(ServerMessage):
+    MessageBody: None

--- a/VSharp.ML.AIAgent/main.py
+++ b/VSharp.ML.AIAgent/main.py
@@ -1,5 +1,6 @@
 import torch
 
+from agent.connection_manager import ConnectionManager
 from agent.n_agent import get_server_maps
 from ml.torch_model_wrapper import TorchModelWrapper
 from ml.mutation_gen import MutationProportions
@@ -7,10 +8,12 @@ from ml.mutation_gen import MutatorConfig
 from ml.models import GCN
 
 from r_learn import r_learn
-from r_learn import DEFAULT_URL
 
 
 def main():
+    socket_urls = ["ws://0.0.0.0:8080/gameServer"]
+    cm = ConnectionManager(socket_urls)
+
     model = GCN(hidden_channels=64)
     optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
     criterion = torch.nn.CrossEntropyLoss()
@@ -21,7 +24,7 @@ def main():
 
     models = [TorchModelWrapper(model, optimizer, criterion) for _ in range(n_models)]
 
-    maps = get_server_maps(DEFAULT_URL)
+    maps = get_server_maps(cm)
 
     mutator_config = MutatorConfig(
         proportions=MutationProportions(
@@ -35,7 +38,9 @@ def main():
         mutation_freq=2,
     )
 
-    r_learn(epochs, max_steps, models, maps, mutator_config)
+    r_learn(epochs, max_steps, models, maps, mutator_config, cm)
+
+    cm.close()
 
 
 if __name__ == "__main__":

--- a/VSharp.ML.AIAgent/ml/mutation_gen.py
+++ b/VSharp.ML.AIAgent/ml/mutation_gen.py
@@ -37,7 +37,7 @@ class Mutator:
         self.config = config
 
     def n_tops(self, iteration_data, n) -> list[TorchModelWrapper]:
-        # топ по каждой карте (должны быть уникальны?)
+        # топ по каждой карте
         n_tops = []
         for game_map in iteration_data.keys():
             n_tops.extend(
@@ -60,7 +60,6 @@ class Mutator:
     def averaged_all(self, iteration_data) -> TorchModelWrapper:
         # среднее по всем отобранным нейронкам
 
-        # должны ли все нейронки быть уникальны?
         all = []
         for game_map in iteration_data.keys():
             all.extend(

--- a/VSharp.ML.AIAgent/r_learn.py
+++ b/VSharp.ML.AIAgent/r_learn.py
@@ -3,13 +3,11 @@ from itertools import product
 from collections import defaultdict
 
 from common.game import GameMap, Reward, MoveReward
+from agent.connection_manager import ConnectionManager
 from agent.n_agent import NAgent
 from ml.torch_model_wrapper import TorchModelWrapper
 from ml.mutation_gen import MutatorConfig, Mutator
 from ml.mutation_gen import IterationResults
-
-
-DEFAULT_URL = "ws://0.0.0.0:8080/gameServer"
 
 
 def generate_games(models: list[TorchModelWrapper], maps: list[GameMap]):
@@ -18,32 +16,28 @@ def generate_games(models: list[TorchModelWrapper], maps: list[GameMap]):
 
 
 # вот эту функцию можно параллелить (внутренний for, например)
-def r_learn_iteration(models, maps, steps) -> IterationResults:
+def r_learn_iteration(models, maps, steps, ws) -> IterationResults:
     games = generate_games(models, maps)
     iteration_data: IterationResults = defaultdict(list)
 
     for model, map in games:
-        with closing(
-            NAgent(url=DEFAULT_URL, map_id_to_play=map.Id, steps=steps, log=True)
-        ) as agent:
+        with closing(NAgent(ws, map_id_to_play=map.Id, steps=steps, log=True)) as agent:
             cumulative_reward = MoveReward(0, 0)
 
-            for _ in range(steps):
-                game_state = agent.recv_state_from_server()
-                model.train(
-                    game_state,
-                    lambda state_id: agent.send_step(
-                        next_state_id=state_id,
-                        predicted_usefullness=42.0,  # пока оставить 42
-                    ),
-                )
+            try:
+                for _ in range(steps):
+                    game_state = agent.recv_state_or_throw_gameover()
+                    agent.send_step(
+                        next_state_id=0,
+                        predicted_usefullness=42.0,  # left it a constant for now
+                    )
 
-                match agent.recv_reward():
-                    case Reward() as reward:
-                        cumulative_reward += reward.ForMove
-                    case NAgent.StepsCount:
-                        # if it should be accounted for when teaching NN
-                        break
+                    reward = agent.recv_reward_or_throw_gameover()
+                    cumulative_reward += reward.ForMove
+                _ = agent.recv_state_or_throw_gameover()  # wait for gameover
+
+            except NAgent.GameOver:
+                break
 
             iteration_data[map].append((model, cumulative_reward))
 
@@ -56,8 +50,9 @@ def r_learn(
     models: list[TorchModelWrapper],
     maps,
     mutator_config: MutatorConfig,
+    connection_manager: ConnectionManager,
 ):
     mutator = Mutator(mutator_config)
     for _ in range(epochs):
-        iteration_data = r_learn_iteration(models, maps, steps)
+        iteration_data = r_learn_iteration(models, maps, steps, connection_manager)
         models = mutator.new_generation(iteration_data)

--- a/VSharp.ML.AIAgent/r_learn.py
+++ b/VSharp.ML.AIAgent/r_learn.py
@@ -2,7 +2,7 @@ from contextlib import closing
 from itertools import product
 from collections import defaultdict
 
-from common.game import GameMap, Reward, MoveReward
+from common.game import GameMap, MoveReward
 from agent.connection_manager import ConnectionManager
 from agent.n_agent import NAgent
 from ml.torch_model_wrapper import TorchModelWrapper


### PR DESCRIPTION
## фикс:
- добавил проверку ```raise_if_gameover``` на прием сообщений, которые могут gameover содержать
- подробил общий класс серверных сообщений на много маленьких, так как датаклассы, видимо, не предназначены для обработки нескольких значений внутри поля
- убрал проверки состояния агента (и вообще всю верификацию состояний агента убрал, кажется, что только мешает. Проблема неправильного порядка сообщений коммуницируется таким же образом через выкидывание ошибок при попытка десериализовать полученное сообщение в неправильную структуру)

не относится к фиксу:
- создал `ConnectionManager`, который выдает вебсокеты (пока только один), сделал его на будущее для параллельного обучения моделей