### PR TITLE
Fix ActualCoverageDeser

### DIFF
--- a/VSharp.ML.AIAgent/agent/messages.py
+++ b/VSharp.ML.AIAgent/agent/messages.py
@@ -120,6 +120,10 @@ class MapsServerMessage(ServerMessage):
 
 
 @dataclass
+class GameOverServerMessageBody:
+    ActualCoverage: Optional[float]
+
+
+@dataclass
 class GameOverServerMessage(ServerMessage):
-    MessageBody: None
-    ActualCoverage: Optional[int] = None
+    MessageBody: GameOverServerMessageBody

--- a/VSharp.ML.AIAgent/agent/n_agent.py
+++ b/VSharp.ML.AIAgent/agent/n_agent.py
@@ -99,12 +99,9 @@ class NAgent:
                 deser_msg = GameOverServerMessage.from_json_handle(
                     msg, expected=GameOverServerMessage
                 )
-                # TODO: remove if
-                if deser_msg.ActualCoverage is not None:
-                    print(f"{deser_msg.ActualCoverage=}")
                 self.game_is_over = True
                 logging.debug(f"--> {matching_message_type}")
-                raise NAgent.GameOver(deser_msg.ActualCoverage)
+                raise NAgent.GameOver(deser_msg.MessageBody.ActualCoverage)
             case _:
                 return msg
 


### PR DESCRIPTION
Сервер отправляет покрытие, десериализация работает
[app.log](https://github.com/gsvgit/VSharp/files/11644954/app.log)

но:
1) приходят странные значения покрытия и наград
2) на моей машине при запуске двух серверов после сыгранной игры и пройденного теста сокет отваливался с `[09:59:49 INF] WebSocket disconnected ConnectionError "Connection reset by peer"`