### PR TITLE
Updated ML.GameServer.Runner to net8

### DIFF
--- a/VSharp.ML.GameServer.Runner/VSharp.ML.GameServer.Runner.fsproj
+++ b/VSharp.ML.GameServer.Runner/VSharp.ML.GameServer.Runner.fsproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>VSharp.ML.GameServer</RootNamespace>
     </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.0",
+    "version": "8.0.0",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Updated ML.GameServer.Runner to .NET 8 to fix the "System.Runtime, Version=8.0.0.0" error seen with the new methods.